### PR TITLE
Add support for downloads from GitHub

### DIFF
--- a/src/components/editors/remote/remote_editors.gd
+++ b/src/components/editors/remote/remote_editors.gd
@@ -30,6 +30,7 @@ const platforms = {
 @onready var _direct_link_button: Button = %DirectLinkButton
 @onready var _check_box_container: HFlowContainer = %CheckBoxContainer
 @onready var _refresh_button: Button = %RefreshButton
+@onready var _github_checkbox: CheckBox = %GithubCheckbox
 
 var _current_platform
 var _root_loaded = false
@@ -44,6 +45,8 @@ func _ready():
 	_detect_platform()
 	_setup_tree()
 	_setup_checkboxes()
+	
+	_github_checkbox.get_parent().move_child(_github_checkbox, 1)
 	
 	var scroll_container = %ScrollContainer
 	var editors_downloads = %EditorDownloads

--- a/src/components/editors/remote/remote_editors.gd
+++ b/src/components/editors/remote/remote_editors.gd
@@ -391,7 +391,8 @@ func _restore_url(item: TreeItem, use_github: bool = false):
 ## valid Github URL.
 func _tux_zip_url_to_github(tux_url: String) -> String:
 	var version = tux_url.trim_prefix(url).split("/", false, 1)[0]
-	if not (version >= "3.1.1" or version == "2.1.6") or not ".zip" in tux_url:
+	if (not (version >= "3.1.1" or version == "2.1.6")
+			or not ".zip" in tux_url or not "-stable_" in tux_url):
 		return ""
 	
 	var result_url = tux_url.replace(url, github_url)

--- a/src/components/editors/remote/remote_editors.gd
+++ b/src/components/editors/remote/remote_editors.gd
@@ -48,6 +48,9 @@ func _ready():
 	_setup_checkboxes()
 	
 	_github_checkbox.get_parent().move_child(_github_checkbox, 1)
+	_github_checkbox.button_pressed = Config.get_use_github()
+	_github_checkbox.toggled.connect(func (use_github: bool):
+		Config.set_use_github(use_github))
 	
 	var scroll_container = %ScrollContainer
 	var editors_downloads = %EditorDownloads

--- a/src/components/editors/remote/remote_editors.gd
+++ b/src/components/editors/remote/remote_editors.gd
@@ -219,14 +219,18 @@ func _setup_tree():
 		if not item.has_meta("file_name"): return
 		var file_name = item.get_meta("file_name")
 		var url = _restore_url(item, _github_checkbox.button_pressed)
-		download_zip(url, file_name)
+		if _github_checkbox.button_pressed:
+			download_zip(url, file_name, _restore_url(item, false))
+		else:
+			download_zip(url, file_name)
 	)
 
 
-func download_zip(url, file_name):
+func download_zip(url, file_name, tux_fallback = ""):
 	var editor_download = _editor_download_scene.instantiate()
 	%EditorDownloads.add_child(editor_download)
-	editor_download.start(url, Config.DOWNLOADS_PATH + "/", file_name)
+	editor_download.start(url, Config.DOWNLOADS_PATH + "/", file_name,
+			tux_fallback)
 	editor_download.downloaded.connect(func(abs_path):
 		install_zip(
 			abs_path, 

--- a/src/components/editors/remote/remote_editors.tscn
+++ b/src/components/editors/remote/remote_editors.tscn
@@ -77,7 +77,13 @@ unique_name_in_owner = true
 layout_mode = 2
 text = "Refresh"
 
-[node name="HSeparator" parent="VBoxContainer/HBoxContainer/ActionsSidebar" index="1"]
+[node name="GithubCheckbox" type="CheckBox" parent="VBoxContainer/HBoxContainer/ActionsSidebar"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Will download files from github when possible, if enabled."
+text = "Use Github"
+
+[node name="HSeparator" parent="VBoxContainer/HBoxContainer/ActionsSidebar" index="2"]
 visible = false
 
 [connection signal="visibility_changed" from="." to="." method="_on_visibility_changed"]

--- a/src/config.gd
+++ b/src/config.gd
@@ -143,3 +143,12 @@ func set_project_creating_last_selected_path(value):
 
 func get_auto_close():
 	return _cfg.get_value("app", "auto_close", false)
+
+
+func get_use_github():
+	return _cfg.get_value("app", "use_github", false)
+
+
+func set_use_github(value):
+	_cfg.set_value("app", "use_github", value)
+	_cfg.save(APP_CONFIG_PATH)


### PR DESCRIPTION
This PR adds a setting to allow Godots to download releases from Github whenever possible (stable releases newer than 3.1.1 and the version 2.1.6).  If the download fails, Godots will fallback to TuxFamily.

The setting can be enabled in the remote editors tab, by toggling the checkbox on the right that says «Use Github».

I had considered adding an `OptionButton` to each `TreeItem` for a release's zip, to allow the user to explicitly choose the mirror to use when downloading (as was done in https://gitlab.com/jwestman/hourglass/-/merge_requests/43), but that was not possible, since a `TreeItem` only allows for normal buttons to be added.