### PR TITLE
Implement checking for the integrity of downloaded remote releases.

### DIFF
--- a/src/components/editors/remote/remote_editor_download/remote_editor_download.gd
+++ b/src/components/editors/remote/remote_editor_download/remote_editor_download.gd
@@ -4,6 +4,8 @@ const uuid = preload("res://addons/uuid.gd")
 
 signal downloaded(abs_zip_path: String)
 
+const _CHECKSUM_FILENAME = "SHA512-SUMS.txt"
+
 var _retry_callback
 var _url: String
 var _fallback_url: String = "":
@@ -100,10 +102,21 @@ func start(url, target_abs_dir, file_name, fallback_url = ""):
 			if _fallback_url:
 				_mirror_switch_button.show()
 			_status.text = status
+			return
 		else:
-			_install_button.disabled = false
-			_status.text = "Ready to install"
-			downloaded.emit(_download.download_file)
+			_status.text = "Checking file integrity..."
+			if not await _check_file_integrity():
+				$AcceptErrorDialog.dialog_text = "Integrity check failed!\n" + \
+						"Retry or use another mirror."
+				$AcceptErrorDialog.popup_centered()
+				_retry_button.show()
+				if _fallback_url:
+					_mirror_switch_button.show()
+					return
+		
+		_install_button.disabled = false
+		_status.text = "Ready to install"
+		downloaded.emit(_download.download_file)
 	
 	assert(target_abs_dir.ends_with("/"))
 	print("Downloading " + url)
@@ -171,8 +184,55 @@ func _notification(what: int) -> void:
 		_remove_downloaded_file()
 
 
+## Checks integrity of the downloaded file by veryfing that the SHA512
+## checksum is correct.  Downloads SHA512-SUMS.txt to do so.[br]
+##
+## The authenticity of that checksum cannot be verified, however.[br]
+##
+## Failing to download SHA512-SUMS.txt is treated as success, because, again,
+## this method does not verify authenticity of the release.[br]
+##
+## Returns true on success and false on failure.
+func _check_file_integrity() -> bool:
+	var checksum_url: String = _url.get_base_dir().path_join(_CHECKSUM_FILENAME)
+	var checksum_downloader := HTTPRequest.new()
+	checksum_downloader.download_file = _target_abs_dir.get_base_dir() \
+			.path_join(_CHECKSUM_FILENAME)
+	checksum_downloader.timeout = 10
+	checksum_downloader.download_chunk_size = 2048
+	print("Downloading ", checksum_url)
+	add_child(checksum_downloader)
+	checksum_downloader.request(checksum_url)
+	var sig_result = await checksum_downloader.request_completed
+	var result = sig_result[0]
+	var response_code = sig_result[1]
+	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
+		return true
+	
+	var globalized_directory_path = ProjectSettings.globalize_path(_target_abs_dir)
+	match OS.get_name():
+		"Linux", "OpenBSD", "FreeBSD", "NetBSD", "BSD":
+			var status = OS.execute("bash", ["-c", "cd " + globalized_directory_path
+					+ " && sha512sum -c --ignore-missing --status "
+					+ _CHECKSUM_FILENAME])
+			return status == 0 or status == 127
+		"Windows":
+			return true #TODO
+		"macOS":
+			return true #TODO
+		_:
+			return true
+	
+	checksum_downloader.queue_free()
+
+
 func _remove_downloaded_file():
 	if _download.download_file:
 		DirAccess.remove_absolute(
 			ProjectSettings.globalize_path(_download.download_file)
+		)
+	var sum_file_path = _target_abs_dir.path_join(_CHECKSUM_FILENAME)
+	if FileAccess.file_exists(sum_file_path):
+		DirAccess.remove_absolute(
+			ProjectSettings.globalize_path(sum_file_path)
 		)

--- a/src/components/editors/remote/remote_editor_download/remote_editor_download.tscn
+++ b/src/components/editors/remote/remote_editor_download/remote_editor_download.tscn
@@ -68,6 +68,11 @@ layout_mode = 2
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="MirrorSwitchButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
 [node name="RetryButton" type="Button" parent="MarginContainer/HBoxContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2


### PR DESCRIPTION
This PR implements checking the integrity of downloaded remote releases, by comparing their sha512 sum.

Note that this PR does not verify the authenticity of the release.  Doing so is impossible to do, because Godot does not at this time sign their checksums.  There is however a proposal to do so (https://github.com/godotengine/godot-proposals/issues/6042).  Therefore, the absence of a SHA512-SUMS.txt (and therefore the impossibility of checking the file's integrity) does not constitute a failure and is simply ignored.

Currently implemented for:
- [X] Linux and BSD
- [ ] Windows
- [ ] The Apple operating system

This was implemented using system commands, because Godot doesn't at this moment natively support SHA512.
I only have a Linux system to test on and therefore was only able to write the code for Linux and BSD (assuming those generally have the `sha512sum` binary installed).  I think on Windows one could use `certutil`. And maybe Apple systems also have `sha512sum`, but I don't know anyone with an Apple system.