### PR TITLE
Fix editor import dialog appearing multiple times after finishing a download that has its retry button pressed.

### DIFF
--- a/src/components/editors/remote/remote_editor_download/remote_editor_download.gd
+++ b/src/components/editors/remote/remote_editor_download/remote_editor_download.gd
@@ -114,6 +114,8 @@ func start(url, target_abs_dir, file_name, tux_fallback = ""):
 			_status.text = "Something went wrong."
 		return
 	
+	for connection in _download.request_completed.get_connections():
+		_download.request_completed.disconnect(connection.callable)
 	_download.request_completed.connect(download_completed_callback.bind(download_completed_callback))
 	
 	#TODO handle deadlock


### PR DESCRIPTION
This PR fixes the bug wherein retrying a download leads to it popping up multiple install dialogues when it finishes.

I closed https://github.com/MakovWait/godots/pull/12 because I included a commit that was not supposed to be there.