### PR TITLE
Add files for packaging on Linux

### DIFF
--- a/packaging/linux/io.github.MakovWait.Godots.appdata.xml
+++ b/packaging/linux/io.github.MakovWait.Godots.appdata.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>io.github.MakovWait.Godots</id>
+  <name>Godots</name>
+  <summary>Godot game engine version manager</summary>
+  <description>
+    <p>Godots is the ultimate hub for managing your Godot versions and projects.</p>
+    <p>Download different versions of Godot and work across multiple projects with gdscript or the integrated C# support.</p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <url type="homepage">https://github.com/MakovWait/godots/</url>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://github.com/MakovWait/godots/blob/main/.github/assets/screenshot2.png?raw=true</image>
+      <caption>Editors</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="v1.0.stable" date="2023-08-16"/>
+  </releases>
+</component>

--- a/packaging/linux/io.github.MakovWait.Godots.desktop
+++ b/packaging/linux/io.github.MakovWait.Godots.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Godots
+GenericName=Libre game engine version manager
+Comment=Ultimate go-to hub for managing your Godot versions and projects!
+Exec=godots
+Icon=godots
+Terminal=false
+PrefersNonDefaultGPU=true
+Type=Application
+Categories=Development;IDE;
+StartupWMClass=Godot


### PR DESCRIPTION
This is meant for packaging Godots on Flatpak using upstreamed files. This isn't meant for use by Godots itself. The desktop file in particular assumes that `godots` is placed in the user's `PATH`, instructions for how to do this could be provided if necessary. I'm unsure if that would need to be within this PR though.