### PR TITLE
Fix ok button not updating when file selected

### DIFF
--- a/src/components/editors/local/editor_import/editor_import.gd
+++ b/src/components/editors/local/editor_import/editor_import.gd
@@ -28,6 +28,7 @@ func _ready() -> void:
 	_file_dialog.file_selected.connect(func(dir):
 		_path_edit.text = dir
 		_name_edit.text = utils.guess_editor_name(dir)
+		_update_ok_button()
 	)
 	_file_dialog.dir_selected.connect(func(path):
 		_path_edit.text = path


### PR DESCRIPTION
Add a call to _update_ok_button when files are selected.

It appears that the line edit text changed signal is not detecting the changes to the path edit or name edit nodes text values via code. As such _update_ok_button was not getting called when expected leading to the ok button being disabled when a valid path is inputted.

Adding a call to _update_ok_button when a file is selected means it will check if confirmation should be allowed when expected.

Fixes #25 