### PR TITLE
Godots cli, help command

### DIFF
--- a/src/cli/cli_command.gd
+++ b/src/cli/cli_command.gd
@@ -1,0 +1,12 @@
+class_name CliCommand
+
+var namesp: String
+var verb: String
+var description: String
+var options: Array[CliOption] = []
+
+func _init(namesp: String, verb: String, description: String, options: Array[CliOption]):
+	self.namesp = namesp
+	self.verb = verb
+	self.description = description
+	self.options = options

--- a/src/cli/cli_command.gd
+++ b/src/cli/cli_command.gd
@@ -10,3 +10,20 @@ func _init(namesp: String, verb: String, description: String, options: Array[Cli
 	self.verb = verb
 	self.description = description
 	self.options = options
+
+func to_help_string(padding: int) -> String:
+	var result: PackedStringArray = []
+
+	if not self.verb.is_empty():
+		result.append("\t%s - %s" % [ljust(self.verb, padding), description])
+
+	for option in options:
+		result.append("\t\t%s" % option.to_help_string())
+
+	return "\n".join(result)
+
+static func ljust(input: String, width: int) -> String:
+	var output = input
+	while output.length() < width:
+		output += " "
+	return output

--- a/src/cli/cli_option.gd
+++ b/src/cli/cli_option.gd
@@ -1,0 +1,12 @@
+class_name CliOption
+
+var description: String
+var usage: String
+var short: String
+var long: String
+
+func _init(long: String, short: String, description: String, usage: String):
+	self.long = "--%s" % long
+	self.short = "-%s" % short
+	self.description = description
+	self.usage = usage

--- a/src/cli/cli_option.gd
+++ b/src/cli/cli_option.gd
@@ -10,3 +10,6 @@ func _init(long: String, short: String, description: String, usage: String):
 	self.short = "-%s" % short
 	self.description = description
 	self.usage = usage
+
+func to_help_string() -> String:
+	return "%s|%s \t %s" % [long, short, description]

--- a/src/cli/godots_commands.gd
+++ b/src/cli/godots_commands.gd
@@ -1,0 +1,16 @@
+class_name GodotsCommands
+
+static var commands: Array[CliCommand] = [
+	CliCommand.new(
+		"",
+		"",
+		"Shows the global help menu.",
+		[
+			CliOption.new(
+				"ghelp",
+				"gh",
+				"Displays global help information.",
+				"--ghelp or -gh")
+		]
+	)
+]

--- a/src/cli/help/help.gd
+++ b/src/cli/help/help.gd
@@ -1,0 +1,38 @@
+class_name Help
+
+func print_commands(commands: Array[CliCommand]):
+	var commands_by_namespace: Dictionary = {}
+
+	for command in commands:
+		if not commands_by_namespace.has(command.namesp):
+			commands_by_namespace[command.namesp] = []
+		commands_by_namespace[command.namesp].append(command)
+
+	if commands_by_namespace.has(""):
+		var global_commands = commands_by_namespace[""].filter(func(c): return c.verb.is_empty())
+		if not global_commands.is_empty():
+			Output.push("Usage: godots [arguments]")
+			_print_commands(global_commands)
+		var verb_commands = commands_by_namespace[""].filter(func(c): return not c.verb.is_empty())
+		if not verb_commands.is_empty():
+			Output.push("")
+			Output.push("Usage: godots [command verb] [arguments]")
+			_print_commands(verb_commands)
+
+	commands_by_namespace.erase("")
+
+	if not commands_by_namespace.is_empty():
+		Output.push("")
+		Output.push("Usage: godots [namespace] [verb] [arguments]")
+		Output.push("")
+		for nsp in commands_by_namespace:
+			Output.push("%s ->" % nsp)
+			_print_commands(commands_by_namespace[nsp])
+
+func _print_commands(commands) -> void:
+	var max_length = 0
+	for cmd in commands:
+		max_length = max(max_length, cmd.verb.length())
+	for command in commands:
+		Output.push(command.to_help_string(max_length))
+		Output.push("")

--- a/src/cli/parser/cli_grammar.gd
+++ b/src/cli/parser/cli_grammar.gd
@@ -1,0 +1,51 @@
+class_name CliGrammar
+
+var _commands = []
+
+func _init(commands: Array[CliCommand]):
+	self._commands = commands
+
+func flag_name_forms(namesp: String, verb: String, flag: String) -> Array[String]:
+	var command = _find_command(namesp, verb)
+	if command:
+		for option in command.options:
+			if option.long == flag or option.short == flag:
+				return [option.long, option.short]
+	return []
+
+func supports_flag(namesp: String, verb: String, flag: String) -> bool:
+	var command = _find_command(namesp, verb)
+	if command:
+		for option in command.options:
+			if option.long == flag or option.short == flag:
+				return true
+	return false
+
+func supports_verb(namesp: String, verb: String) -> bool:
+	return _find_command(namesp, verb) != null
+
+func supports_namespace(namesp: String) -> bool:
+	for command in _commands:
+		if command.namesp == namesp:
+			return true
+	return false
+
+func namespaces() -> Array[String]:
+	var namespaces: Array[String] = []
+	for command in _commands:
+		if not namespaces.has(command.namesp):
+			namespaces.append(command.namesp)
+	return namespaces
+
+func verbs(ns: String) -> Array[String]:
+	var verbs: Array[String] = []
+	for command in _commands:
+		if command.namesp == ns:
+			verbs.append(command.verb)
+	return verbs
+
+func _find_command(namesp: String, verb: String) -> CliCommand:
+	for command in _commands:
+		if command.namesp == namesp and command.verb == verb:
+			return command
+	return null

--- a/src/cli/parser/cli_parser.gd
+++ b/src/cli/parser/cli_parser.gd
@@ -1,0 +1,181 @@
+class_name CliParser
+
+static func _to_array_string(array: Array) -> Array[String]:
+	var result: Array[String] = []
+	result.append_array(array)
+	return result
+
+class ParsedOption:
+	var long_name: String
+	var short_name: String
+	var failed: bool = false
+
+	var values: Array[String] = []
+
+	func _init(long, short, values: Array[String], failed):
+		long_name = long
+		short_name = short
+		self.values = values
+		self.failed = failed
+
+	func has_name(name: String) -> bool:
+		return name == long_name or name  == short_name
+
+	func names_equal(option: ParsedOption) -> bool:
+		return has_name(option.long_name) or has_name(option.short_name)
+
+class ParsedCommandResult:
+	var namesp: String
+	var verb: String
+	var options: Dictionary = {}
+	var names: Array[String] = []
+	var errors: Array[String] = []
+
+	func _init(namesp: String, verb: String, options: Array[ParsedOption], names: Array[String]):
+		self.namesp = namesp
+		self.verb = verb
+		self.names = names
+		for option in options:
+			self.options[option.long_name] = option
+			self.options[option.short_name] = option
+
+	func has_error() -> bool:
+		return not errors.is_empty()
+
+	func has_options(names: Array[String]) -> bool:
+		for name in names:
+			if options.has(name):
+				return true
+		return false
+
+	func get_first_present_option_value(names: Array[String]) -> String:
+		for name in names:
+			if options.has(name) and not options[name].values.is_empty():
+				return options[name].values.front()
+		return ""
+
+	func get_first_present_option_values(names: Array[String]) -> Array[String]:
+		for name in names:
+			if options.has(name):
+				return options[name].values
+		return []
+
+	func option_value(name: String) -> String:
+		if options.has(name) and not options[name].values.is_empty():
+			return options[name].values.front()
+		return ""
+
+	func option_values(name: String) -> Array[String]:
+		if options.has(name):
+			return options[name].values
+		return []
+
+class CommandParser: 
+	var _tokens : Array = []
+	var current_token_index : int = 0
+
+	var _grammar: CliGrammar
+
+	var token:
+		get: 
+			if _has_tokens():
+				return _tokens[current_token_index]
+			return ""
+
+	var _last_errors: Array[String] = []
+
+	func _init(grammar: CliGrammar):
+		self._grammar = grammar
+
+	func parse_command(tokens: Array[String]) -> ParsedCommandResult:
+		_tokens = tokens
+		_last_errors = []
+		current_token_index = 0
+
+		var namesp = _expect_namespace()
+		var verb = _expect_verb(namesp)
+		var options: Array[ParsedOption] = []
+		var names: Array[String] = _parse_names()
+
+		while _has_tokens():
+			var option: ParsedOption = _parse_option(namesp, verb)
+
+			if option.failed:
+				break;
+
+			if options.any(func(o): return o.names_equal(option)):
+				_raise_error("Only one option with name (`%s`, `%s`) can be used." % [option.long_name, option.short_name])
+			else:
+				options.append(option)
+
+		var command = ParsedCommandResult.new(namesp, verb, options, names)
+		command.errors = _last_errors
+		return command
+
+	func _parse_option(namesp: String, verb: String) -> ParsedOption:
+		var long_name = ""
+		var short_name = ""
+		var values: Array[String] = []
+		var failed = false
+
+		if _is_option(token):
+			if _grammar.supports_flag(namesp, verb, token):
+				var name_forms = _grammar.flag_name_forms(namesp, verb, token)
+				long_name = _adjust_flag_token_name(name_forms[0])
+				short_name = _adjust_flag_token_name(name_forms[1])
+
+				_next_token()
+	
+				while _has_tokens() and not _is_option(token):
+					values.append(token)
+					_next_token()
+			else:
+				_raise_error("Unsupported option: %s" % token)
+				failed = true
+				_next_token()
+		else:
+			_raise_error("Invalid token found instead of option name: %s" % token)
+			failed = true
+			_next_token()
+
+		return ParsedOption.new(long_name, short_name, values, failed)
+
+	func _parse_names() -> Array[String]:
+		var result: Array[String] = []
+
+		while _has_tokens() and not _is_option(token):
+			result.append(token)
+			_next_token()
+
+		return result
+
+	func _expect_namespace() -> String:
+		if not _grammar.supports_namespace(token):
+			return ""
+
+		var result = token
+		_next_token()
+		return result
+
+	func _expect_verb(scope: String) -> String:
+		if not _grammar.supports_verb(scope, token):
+			return ""
+
+		var result = token;
+		_next_token()
+		return result
+
+	func _adjust_flag_token_name(token: String) -> String:
+		return token.substr(2, token.length()) if token.begins_with("--") else token.substr(1, token.length())
+
+	func _is_option(token: String) -> bool:
+		return token.begins_with("-")
+
+	func _raise_error(message: String) -> void:
+		_last_errors.push_back(message)
+
+	func _next_token() -> void:
+		current_token_index += 1
+
+	func _has_tokens() -> bool:
+		return current_token_index < _tokens.size()

--- a/src/main/cli/cli_main.gd
+++ b/src/main/cli/cli_main.gd
@@ -1,0 +1,17 @@
+class_name CliMain
+
+static func execute(cmd: CliParser.ParsedCommandResult, user_args: PackedStringArray):
+	if cmd.namesp == "" and cmd.verb == "":
+		Help.new().print_commands(GodotsCommands.commands)
+
+static func main(args: PackedStringArray, app_args: PackedStringArray):
+	if (args.size() >= 1):
+
+		var parser = CliParser.CommandParser.new(CliGrammar.new(GodotsCommands.commands))
+		var cmd = parser.parse_command(args)
+
+		if not cmd.has_error():
+			execute(cmd, app_args)
+		else:
+			Output.push("Errors: \n" + "\t\n".join(cmd.errors))
+	pass

--- a/src/main/main.gd
+++ b/src/main/main.gd
@@ -2,6 +2,26 @@ extends Node
 
 @export_file() var gui_scene_path: String
 
+func _ready():
+	var args = OS.get_cmdline_args()
+	var user_args = OS.get_cmdline_user_args()
 
-func _enter_tree():
-	add_child(load(gui_scene_path).instantiate())
+	if _is_cli_mode(args):
+		Output.push("Run cli mode")
+		var adjusted_args = args.slice(1) if OS.has_feature("editor") else args
+		CliMain.main(adjusted_args, user_args)
+		_exit()
+	else:
+		Output.push("Run window mode")
+		add_child.call_deferred(load(gui_scene_path).instantiate())
+	pass
+
+func _is_cli_mode(args: PackedStringArray) -> bool:
+	if args.size() > 1 and OS.has_feature("editor"):
+		return true
+	elif args.size() >= 1 and OS.has_feature("template"):
+		return true
+	return false
+
+func _exit():
+	get_tree().quit()

--- a/tests/cases/cli/parser/parser_not_ok.gd
+++ b/tests/cases/cli/parser/parser_not_ok.gd
@@ -1,0 +1,34 @@
+class_name CliParserNotOkTests
+extends GdUnitTestSuite
+
+func test_invalid_namespace():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["invalidNamespace"])
+	assert(result.namesp.is_empty())
+	assert(result.verb.is_empty())
+	assert(result.names[0] == "invalidNamespace")
+
+func test_invalid_command():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["namespace1", "invalidVerb"])
+	assert(result.namesp == "namespace1")
+	assert(result.verb.is_empty())
+	assert(result.names[0] == "invalidVerb")
+
+func test_invalid_option():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["namespace1", "verb1", "--invalidOption"])
+	assert(result.has_error())
+	assert(result.errors[0] == "Unsupported option: --invalidOption")
+
+func test_repeated_options():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["namespace1", "verb1", "--flag1", "value1", "--flag1", "value2"])
+	assert(result.has_error())
+	assert(result.errors[0] == "Only one option with name (`flag1`, `f1`) can be used.")
+
+func test_repeated_short_and_long_options():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["namespace1", "verb1", "--flag1", "value1", "-f1", "value2"])
+	assert(result.has_error())
+	assert(result.errors[0] == "Only one option with name (`flag1`, `f1`) can be used.")

--- a/tests/cases/cli/parser/parser_ok.gd
+++ b/tests/cases/cli/parser/parser_ok.gd
@@ -1,0 +1,36 @@
+class_name CliParserOkTests
+extends GdUnitTestSuite
+
+func test_parse_command():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["namespace1", "verb1", "just_name", "--flag1", "value1", "value2", "--bool-flag", "-a"])
+	assert(result.namesp == "namespace1")
+	assert(result.verb == "verb1")
+	assert("just_name" in result.names)
+	assert("value1" in result.option_values("flag1"))
+	assert("value2" in result.option_values("flag1"))
+	assert(result.has_options(["bool-flag"]))
+	assert(result.has_options(["a"]))
+
+func test_parse_without_verb():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["namespace1", "just_name", "--flag1", "value1", "value2", "--bool-flag", "-a"])
+	assert(result.namesp == "namespace1")
+	assert(result.verb == "")
+	assert("just_name" in result.names)
+	assert("value1" in result.option_values("flag1"))
+	assert("value2" in result.option_values("flag1"))
+	assert(result.has_options(["bool-flag"]))
+	assert(result.has_options(["a"]))
+
+
+func test_parse_without_namespace_and_verb():
+	var parser = CliParser.CommandParser.new(TestGrammar.grammar)
+	var result = parser.parse_command(["just_name", "--flag1", "value1", "value2", "--bool-flag", "-a"])
+	assert(result.namesp == "")
+	assert(result.verb == "")
+	assert("just_name" in result.names)
+	assert("value1" in result.option_values("flag1"))
+	assert("value2" in result.option_values("flag1"))
+	assert(result.has_options(["bool-flag"]))
+	assert(result.has_options(["a"]))

--- a/tests/cases/cli/parser/test_grammar.gd
+++ b/tests/cases/cli/parser/test_grammar.gd
@@ -1,0 +1,49 @@
+class_name TestGrammar
+
+static var grammar = CliGrammar.new([
+	CliCommand.new(
+		"namespace1",
+		"verb1",
+		"",
+		[
+			CliOption.new("flag1", "f1", "", ""),
+			CliOption.new("bool-flag", "bl", "", ""),
+			CliOption.new("auto", "a", "", ""),
+		],
+	),
+	CliCommand.new(
+		"namespace1",
+		"",
+		"",
+		[
+			CliOption.new("flag1", "f1", "", ""),
+			CliOption.new("bool-flag", "bl", "", ""),
+			CliOption.new("auto", "a", "", ""),
+		],
+	),
+	CliCommand.new(
+		"",
+		"",
+		"",
+		[
+			CliOption.new("flag1", "f1", "", ""),
+			CliOption.new("bool-flag", "bl", "", ""),
+			CliOption.new("auto", "a", "", ""),
+		],
+	),
+	CliCommand.new(
+		"namespace1",
+		"verb2",
+		"",
+		[]
+	),
+	CliCommand.new(
+		"namespace2",
+		"verb1",
+		"",
+		[
+			CliOption.new("flag1", "f1", "", ""),
+			CliOption.new("bool-flag", "bl", "", ""),
+		]
+	),
+])


### PR DESCRIPTION
Add GODOTS CLI parser and implementation of help command.

Example of usage: 
- `godots.exe --headless --ghelp`
or 
- `godots.exe --headless -gh`
