### PR TITLE
Add auto editor version search.

### DIFF
--- a/src/cli/open_editor/open_editor.gd
+++ b/src/cli/open_editor/open_editor.gd
@@ -3,10 +3,12 @@ class_name OpenEditor
 class Request:
 	var name_pattern: String
 	var user_args: PackedStringArray
+	var working_dir: String
 
-	func _init(name_pattern: String, user_args: PackedStringArray):
+	func _init(name_pattern: String, user_args: PackedStringArray, working_dir: String = "."):
 		self.name_pattern = name_pattern
 		self.user_args = user_args
+		self.working_dir = working_dir
 
 var _editors: LocalEditors.List
 
@@ -15,18 +17,50 @@ func _init():
 
 func execute(req: Request) -> void:
 	if _editors.load() == Error.OK:
-		var editors = _editors.filter_by_name_pattern(req.name_pattern)
-		if editors.size() == 1:
-			_run_editor(editors[0], req.user_args)
-		elif editors.size() > 1:
-			var names: Array[String] = []
-			for e in editors:
-				names.append(e.name)
-			Output.push("There is ambiguity between editors to run.\n%s" % "\n".join(names))
+		var editor: LocalEditors.Item = null
+
+		if req.name_pattern.is_empty():
+			var project_path = DirAccess.open(req.working_dir).get_current_dir() + "/project.godot"
+			editor = _find_editor_by_proj_godot(project_path)
 		else:
-			Output.push("Required editor is not found!")
+			editor = _find_editor_by_name(req.name_pattern)
+
+		if editor != null:
+			_run_editor(editor, req.user_args)
 	else:
 		Output.push("Some error happend during editors loading!")
+
+func _find_editor_by_proj_godot(project_path: String) -> LocalEditors.Item:
+	var result: LocalEditors.Item = null
+	
+	if FileAccess.file_exists(project_path):
+		var project_info = Projects.ExternalProjectInfo.new(project_path)
+		project_info.load(false)
+
+		if project_info.has_version_hint:
+			result = _editors.retrieve_by_version_hint(project_info.version_hint)
+		else:
+			Output.push("Editor not found as `project.godot` does not have `version_hint`.")
+	else:
+		Output.push("Editor not found as path to `project.godot` does not exist.")
+
+	return result
+
+func _find_editor_by_name(name_pattern: String) -> LocalEditors.Item:
+	var result: LocalEditors.Item = null
+
+	var editors = _editors.filter_by_name_pattern(name_pattern)
+	if editors.size() == 1:
+		result = editors[0]
+	elif editors.size() > 1:
+		var names: Array[String] = []
+		for e in editors:
+			names.append(e.name)
+		Output.push("There is ambiguity between editors to run.\n%s" % "\n".join(names))
+	else:
+		Output.push("Required editor is not found!")
+
+	return result
 
 func _run_editor(editor: LocalEditors.Item, user_args: PackedStringArray) -> void:
 	Output.push("Editor is found by path: %s " % editor.path)

--- a/src/cli/open_editor/open_editor.gd
+++ b/src/cli/open_editor/open_editor.gd
@@ -38,7 +38,7 @@ func _find_editor_by_proj_godot(project_path: String) -> LocalEditors.Item:
 		result = result if result else _find_editor_by_external_project(project_path)
 	
 		if not result:
-			Output.push("Editor not found because it was either not imported into godots or the `project.godot` file does not contain a `version_hint`.")
+			Output.push("Editor not found: either the project isn't bound to an editor or `project.godot` lacks a `version_hint`.")
 	else:
 		Output.push("Editor not found as path to `project.godot` does not exist.")
 

--- a/src/cli/parser/cli_parser.gd
+++ b/src/cli/parser/cli_parser.gd
@@ -32,6 +32,10 @@ class ParsedArguments:
 		for option in options:
 			_options[option.long_name] = option
 			_options[option.short_name] = option
+			
+	func get_first_name(default:="") -> String:
+		var name = names.front()
+		return default if name == null else name
 
 	func has_options(names: Array[String]) -> bool:
 		for name in names:
@@ -40,7 +44,8 @@ class ParsedArguments:
 		return false
 
 	func first_option_value(names: Array[String]) -> String:
-		return first_option_values(names).front()
+		var values = first_option_values(names)
+		return "" if values.is_empty() else values.front()
 
 	func first_option_values(names: Array[String]) -> Array[String]:
 		for name in names:

--- a/src/main/cli/cli_main.gd
+++ b/src/main/cli/cli_main.gd
@@ -5,7 +5,8 @@ static func execute(cmd: CliParser.ParsedCommandResult, user_args: PackedStringA
 		Help.new().print_commands(GodotsCommands.commands)
 	elif cmd.namesp == "editor" and cmd.verb == "run":
 		var name = cmd.args.first_option_value(["name", "n"])
-		OpenEditor.new().execute(OpenEditor.Request.new(name, user_args))
+		var working_dir = cmd.args.get_first_name(".") if name.is_empty() else ""
+		OpenEditor.new().execute(OpenEditor.Request.new(name, user_args, working_dir))
 
 static func main(args: PackedStringArray, app_args: PackedStringArray):
 	if (args.size() >= 1):

--- a/src/services/local_editors.gd
+++ b/src/services/local_editors.gd
@@ -42,6 +42,12 @@ class List extends RefCounted:
 	func retrieve(editor_path) -> Item:
 		return _editors[editor_path]
 	
+	func retrieve_by_version_hint(version_hint: String) -> Item:
+		for e in all():
+			if VersionHint.are_equal(e.version_hint, version_hint):
+				return e
+		return null
+	
 	func filter_by_name_pattern(name_pattern: String) -> Array[Item]:
 		var sanitized_name_pattern = _sanitize_name(name_pattern)
 		var result: Array[Item] = []

--- a/src/services/projects.gd
+++ b/src/services/projects.gd
@@ -93,6 +93,12 @@ class Item:
 		get: return _section.get_value("favorite", false)
 		set(value): _section.set_value("favorite", value)
 	
+	var editor:
+		get: 
+			if has_invalid_editor:
+				return null
+			return _local_editors.retrieve(editor_path)
+	
 	var editor_path:
 		get: return _section.get_value("editor_path", "")
 		set(value): 
@@ -133,12 +139,12 @@ class Item:
 
 	var _external_project_info: ExternalProjectInfo
 	var _section: ConfigFileSection
-	var _local_editors
+	var _local_editors: LocalEditors.List
 	
 	func _init(
 		section: ConfigFileSection, 
 		project_info: ExternalProjectInfo,
-		local_editors
+		local_editors: LocalEditors.List
 	) -> void:
 		self._section = section
 		self._external_project_info = project_info


### PR DESCRIPTION
---
## New Argument for `godots editor run`

The new argument serves as a hint to godots for determining which version of the Godot editor should be launched. This argument represents the path to the project's Godot directory. Initially, Godots will try to open the editor version already bound to the project. If unsuccessful, it will then source the desired version from the version_hint property in the project.godot file.

> **Note:** 
- The path will be ignored if the `--name` flag is passed.
- If the **project isn't bound to the editor** or `version_hint` does not exist in the `project.godot` file, the editor will not open.

### Usage

- By default, the working directory will be used: 
```bash
godots.exe editor run
```

- To specify a project directory: 
```bash
godots.exe editor run "path/to/project/dir"
```

 