### PR TITLE
Open bind editor window when editor is invalid

### DIFF
--- a/src/components/projects/project_item/project_item.gd
+++ b/src/components/projects/project_item/project_item.gd
@@ -151,6 +151,10 @@ func init(item: Projects.Item):
 		edited.emit()
 	)
 	double_clicked.connect(func():
+		if item.has_invalid_editor:
+			_on_rebind_editor(item)
+			return
+		
 		var valid = not (item.has_invalid_editor or item.is_missing)
 		if valid:
 			_on_edit_with_editor(item)


### PR DESCRIPTION
This just adds a simple function that offers to open the "bind editor" window when double clicking a project with an invalid editor.
This edit was done very quickly and I don't really know my way around the program or if there's anything else that should be done for this feature to get merged, so if anything was done wrong here please let me know.