### PR TITLE
Add Linux section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ For all the macOS aficionados out there, unleashing the power of Godots is just 
 sudo xattr -r -d com.apple.quarantine /Applications/Godots.app
 ```
 
+## What about Linux? 🐧
+
+Fear not Linux users, unleashing the power of Godots on any distribution is just a command away in the form of a Flatpak! Ready to run the app? Just install it from Flathub!
+
+<div align="start">
+<a href='https://flathub.org/apps/details/io.github.MakovWait.Godots'><img width="250" alt='Download on Flathub' src='https://raw.githubusercontent.com/flxzt/rnote/main/misc/assets/flathub-badge.svg'/></a>
+</div><br>
+
+Don't have Flatpak? Just download the [latest release](https://github.com/MakovWait/godots/releases/tag/v1.2.2.stable)!
+
 ## Features That Redefine Cool 😎
 - **HIDPI Magic**: Feast your eyes on Godots like never before! With pixel-perfect support for Retina displays, zero blur, and stunning visuals, it's a visual extravaganza.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ sudo xattr -r -d com.apple.quarantine /Applications/Godots.app
 
 Fear not Linux users, unleashing the power of Godots on any distribution is just a command away in the form of a Flatpak! Ready to run the app? Just install it from Flathub!
 
+**Note: This Flatpak is community maintained**
+
 <div align="start">
 <a href='https://flathub.org/apps/details/io.github.MakovWait.Godots'><img width="250" alt='Download on Flathub' src='https://raw.githubusercontent.com/flxzt/rnote/main/misc/assets/flathub-badge.svg'/></a>
 </div><br>


### PR DESCRIPTION
This targets the now-released Flathub build for Linux, but can also include an AppImage build in the future for example, if that is ever needed. Should a disclaimer that the Flatpak is not actually maintained by you, @MakovWait, be included?

This closes #17