### PR TITLE
[CliCommand] Directly call ljust() from type

### DIFF
--- a/src/cli/cli_command.gd
+++ b/src/cli/cli_command.gd
@@ -15,7 +15,7 @@ func to_help_string(padding: int) -> String:
 	var result: PackedStringArray = []
 
 #	if not self.verb.is_empty():
-	result.append("\t%s - %s" % [ljust(self.verb, padding), description])
+	result.append("\t%s - %s" % [CliCommand.ljust(self.verb, padding), description])
 
 	for option in options:
 		result.append("\t\t%s" % option.to_help_string())


### PR DESCRIPTION
Not really a bug but ljust() is a static function.