### PR TITLE
Double clicking tree item starts download

### DIFF
--- a/src/components/editors/remote/remote_editors_tree/data_source.gd
+++ b/src/components/editors/remote/remote_editors_tree/data_source.gd
@@ -81,6 +81,9 @@ class Item:
 	func async_expand(tree: RemoteTree):
 		return
 	
+	func handle_item_activated():
+		pass
+	
 	func handle_button_clicked(col, id, mouse):
 		pass
 	

--- a/src/components/editors/remote/remote_editors_tree/remote_editors_tree.gd
+++ b/src/components/editors/remote/remote_editors_tree/remote_editors_tree.gd
@@ -193,7 +193,7 @@ func _setup_tree():
 
 	_tree.item_activated.connect(func():
 		var delegate = _delegate_of(_tree.get_selected())
-		delegate.handle_button_clicked(null, null, null)
+		delegate.handle_item_activated()
 	)
 
 	_tree.button_clicked.connect(func(item, col, id, mouse):

--- a/src/components/editors/remote/remote_editors_tree/remote_editors_tree.gd
+++ b/src/components/editors/remote/remote_editors_tree/remote_editors_tree.gd
@@ -191,6 +191,11 @@ func _setup_tree():
 #				_expand(delegate)
 	)
 
+	_tree.item_activated.connect(func():
+		var delegate = _delegate_of(_tree.get_selected())
+		delegate.handle_button_clicked(null, null, null)
+	)
+
 	_tree.button_clicked.connect(func(item, col, id, mouse):
 		var delegate = _delegate_of(item)
 		delegate.handle_button_clicked(col, id, mouse)

--- a/src/components/editors/remote/remote_editors_tree/sources/github.gd
+++ b/src/components/editors/remote/remote_editors_tree/sources/github.gd
@@ -115,6 +115,9 @@ class GithubItemBase extends RemoteEditorsTreeDataSource.Item:
 	func async_expand(tree: RemoteTree):
 		return
 	
+	func handle_item_activated():
+		pass
+	
 	func handle_button_clicked(col, id, mouse):
 		pass
 	
@@ -163,6 +166,9 @@ class GithubAssetItem extends GithubItemBase:
 	
 	func _to_filter_target() -> GithubFilterTarget:
 		return GithubFilterTarget.new(_asset.name, false, true, _asset.is_zip)
+
+	func handle_item_activated():
+		_assets.download(_asset.browser_download_url, _asset.file_name)
 
 	func handle_button_clicked(col, id, mouse):
 		_assets.download(_asset.browser_download_url, _asset.file_name)

--- a/src/components/editors/remote/remote_editors_tree/sources/tux_family.gd
+++ b/src/components/editors/remote/remote_editors_tree/sources/tux_family.gd
@@ -96,7 +96,13 @@ class RemoteTreeItemTuxFamily extends RemoteEditorsTreeDataSource.Item:
 			if child.has_meta("delegate"):
 				result.append(child.get_meta("delegate"))
 		return result
-	
+
+	func handle_item_activated():
+		if not _item.has_meta("file_name"): return
+		var file_name = _item.get_meta("file_name")
+		var url = _restore_url(_item)
+		_assets.download(url, file_name)
+
 	func handle_button_clicked(col, id, mouse):
 		if not _item.has_meta("file_name"): return
 		var file_name = _item.get_meta("file_name")


### PR DESCRIPTION
This uses the native [item_activated()](https://docs.godotengine.org/en/stable/classes/class_tree.html#class-tree-signal-item-activated) signal of the Tree element. The `handle_button_clicked` function does not currently make use of the passed in values, therefore passing in `null` does that have an effect. If that functionality changes, this should be redesigned. I'm open to making any requested changes!

Resolves #89 