### PR TITLE
Use `any` as default `type` parameter

### DIFF
--- a/src/components/asset_lib_projects/asset_lib.gd
+++ b/src/components/asset_lib_projects/asset_lib.gd
@@ -3,7 +3,7 @@ class_name AssetLib
 # https://github.com/godotengine/godot-asset-library/blob/master/API.md
 class Params:
 	# any|addon|project
-	var type: String = "project":
+	var type: String = "any":
 		set(value): 
 			assert(value in ["any", "addon", "project"])
 			type = value


### PR DESCRIPTION
Defaulting the `type` query parameter to `any` so it displays all available assets. A UI element could be added to override this if needed.

Resolves #98 