### PR TITLE
Add proxy support

### DIFF
--- a/src/components/settings/settings_window.gd
+++ b/src/components/settings/settings_window.gd
@@ -81,6 +81,18 @@ func _prepare_settings():
 			SettingCheckbox,
 			tr("Will check only stable Godots releases.")
 		)),
+		SettingChangeObserved(SettingCfg(
+			"network/http_proxy/host",
+			Config.HTTP_PROXY_HOST,
+			SettingText,
+			tr("Host")
+		)),
+		SettingChangeObserved(SettingCfg(
+			"network/http_proxy/port",
+			Config.HTTP_PROXY_PORT,
+			SettingPort,
+			tr("Port")
+		)),
 	]
 
 
@@ -331,7 +343,10 @@ class SettingText extends Setting:
 					CompInit.SIZE_FLAGS_HORIZONTAL_EXPAND_FILL(),
 					CompInit.CUSTOM(func(this: LineEdit):
 						self.on_value_changed(func(new_value):
-							this.text = new_value
+							# don't update text if the user is interacting
+							# this prevents the caret from going to postition 0
+							if not this.has_focus():
+								this.text = new_value
 						)
 						this.text_changed.connect(func(new_text):
 							_value = new_text
@@ -339,6 +354,40 @@ class SettingText extends Setting:
 						)
 						pass\
 					)
+				])
+			])
+		])
+		control.add_to(target)
+
+
+class SettingPort extends Setting:
+	func add_control(target):
+		var timer = CompRefs.Simple.new()
+		var control = Comp.new(HBoxContainer, [
+			Comp.new(Timer).ref(timer).on_init(
+				func(this: Timer): this.timeout.connect(self.notify_changed)
+			),
+			CompSettingNameContainer.new(self),
+			CompSettingPanelContainer.new(_tooltip, [
+				Comp.new(SpinBox).on_init([
+					CompInit.TOOLTIP_TEXT(_tooltip),
+					CompInit.ADD_THEME_STYLEBOX_OVERRIDE("focus", StyleBoxEmpty.new()),
+					CompInit.SIZE_FLAGS_HORIZONTAL_EXPAND_FILL(),
+					CompInit.CUSTOM(func(this: SpinBox):
+						# set valid port range
+						this.min_value = 0
+						this.max_value = 65535
+						self.on_value_changed(func(new_value):
+							this.value = new_value
+						)
+						this.value_changed.connect(func(new_text):
+							_value = new_text
+							(timer.value as Timer).start(1)
+						)
+						pass\
+					),
+					# set value after so it fits within range
+					CompInit.VALUE(self._value)
 				])
 			])
 		])

--- a/src/config.gd
+++ b/src/config.gd
@@ -225,6 +225,24 @@ var GLOBAL_CUSTOM_COMMANDS_EDITORS = ConfigFileValue.new(
 	set(_v): _readonly()
 
 
+var HTTP_PROXY_HOST = ConfigFileValue.new(
+	_cfg_auto_save,
+	"app",
+	"http_proxy_host",
+	""
+):
+	set(_v): _readonly()
+
+
+var HTTP_PROXY_PORT = ConfigFileValue.new(
+	_cfg_auto_save,
+	"app",
+	"http_proxy_port",
+	8080
+):
+	set(_v): _readonly()
+
+
 func _enter_tree() -> void:	
 	DirAccess.make_dir_absolute(ProjectSettings.globalize_path(DEFAULT_VERSIONS_PATH))
 	DirAccess.make_dir_absolute(ProjectSettings.globalize_path(DEFAULT_DOWNLOADS_PATH))

--- a/src/config.gd
+++ b/src/config.gd
@@ -227,7 +227,7 @@ var GLOBAL_CUSTOM_COMMANDS_EDITORS = ConfigFileValue.new(
 
 var HTTP_PROXY_HOST = ConfigFileValue.new(
 	_cfg_auto_save,
-	"app",
+	"network",
 	"http_proxy_host",
 	""
 ):
@@ -236,7 +236,7 @@ var HTTP_PROXY_HOST = ConfigFileValue.new(
 
 var HTTP_PROXY_PORT = ConfigFileValue.new(
 	_cfg_auto_save,
-	"app",
+	"network",
 	"http_proxy_port",
 	8080
 ):

--- a/src/http_client.gd
+++ b/src/http_client.gd
@@ -3,6 +3,16 @@ extends Node
 
 func async_http_get(url, headers=[], download_file=null):
 	var http_request = HTTPRequest.new()
+	var proxy_host = Config.HTTP_PROXY_HOST.ret().strip_edges()
+	if not proxy_host.is_empty():
+		http_request.set_http_proxy(
+			proxy_host,
+			Config.HTTP_PROXY_PORT.ret()
+			)
+		http_request.set_https_proxy(
+			proxy_host,
+			Config.HTTP_PROXY_PORT.ret()
+			)
 	add_child(http_request)
 	var response = await async_http_get_using(http_request, url, headers, download_file)
 	http_request.queue_free()

--- a/src/objects/node_component/comp_init.gd
+++ b/src/objects/node_component/comp_init.gd
@@ -63,6 +63,10 @@ static func TEXT(t):
 	return func(c): c.text = c.tr(str(t))
 
 
+static func VALUE(v):
+	return func(c): c.value = v
+
+
 static func CUSTOM(callback):
 	return callback
 


### PR DESCRIPTION
Added proxy host and port to settings. (Same location as the Godot Editor)

![image](https://github.com/user-attachments/assets/62cc6a70-a747-4bab-a9ae-ea2dd2e9491f)

This sets both the HTTP and HTTPS proxy settings for the HTTPClient. As far as I have seen, Godots only make HTTPS requests but this replicates the behavior of the Godot Editor. Note - This will not work with your proxy if it is not configured to work with HTTPS/TLS.

Resolves #88 