### PR TITLE
Added basic theming options inside the theme settings

### DIFF
--- a/src/components/settings/settings_window.tscn
+++ b/src/components/settings/settings_window.tscn
@@ -4,15 +4,15 @@
 
 [node name="SettingsWindow" type="AcceptDialog"]
 position = Vector2i(0, 36)
-size = Vector2i(156, 100)
+size = Vector2i(166, 144)
 visible = true
 script = ExtResource("1_u1xvk")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 offset_left = 8.0
 offset_top = 8.0
-offset_right = 148.0
-offset_bottom = 51.0
+offset_right = 158.0
+offset_bottom = 95.0
 
 [node name="HSplitContainer" type="HSplitContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -31,7 +31,7 @@ size_flags_vertical = 3
 [node name="OpenConfigFileButton" type="Button" parent="VBoxContainer/HSplitContainer/LeftVB"]
 unique_name_in_owner = true
 layout_mode = 2
-text = "Settings  Folder"
+text = "Settings Folder"
 
 [node name="RightVB" type="VBoxContainer" parent="VBoxContainer/HSplitContainer"]
 unique_name_in_owner = true

--- a/src/objects/node_component/comp_init.gd
+++ b/src/objects/node_component/comp_init.gd
@@ -50,7 +50,6 @@ static func ADD_THEME_STYLEBOX_OVERRIDE_FROM_THEME(name, theme_stylebox_name, th
 static func ADD_THEME_STYLEBOX_OVERRIDE(name, stylebox):
 	return func(c: Control): c.add_theme_stylebox_override(name, stylebox)
 
-
 static func SIZE_FLAGS_HORIZONTAL(v):
 	return func(c): c.size_flags_horizontal = v
 

--- a/theme/fonts/DroidSansFallback.woff2.import
+++ b/theme/fonts/DroidSansFallback.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/DroidSansFallback.woff2-9a6b197d8ae3dcc2460b4
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/DroidSansJapanese.woff2.import
+++ b/theme/fonts/DroidSansJapanese.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/DroidSansJapanese.woff2-265c43a1bf482bf9eacbd
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/JetBrainsMono_Regular.woff2.import
+++ b/theme/fonts/JetBrainsMono_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/JetBrainsMono_Regular.woff2-99ded7c951c024f99
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoNaskhArabicUI_Bold.woff2.import
+++ b/theme/fonts/NotoNaskhArabicUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoNaskhArabicUI_Bold.woff2-520684f0ef3fa41c
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoNaskhArabicUI_Regular.woff2.import
+++ b/theme/fonts/NotoNaskhArabicUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoNaskhArabicUI_Regular.woff2-d202fbf2a7f20
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansBengaliUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansBengaliUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansBengaliUI_Bold.woff2-c28c13f059bd163e
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansBengaliUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansBengaliUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansBengaliUI_Regular.woff2-02d737ecfea93
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansDevanagariUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansDevanagariUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansDevanagariUI_Bold.woff2-63ee35eaa15fa
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansDevanagariUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansDevanagariUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansDevanagariUI_Regular.woff2-fb318440d8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansGeorgian_Bold.woff2.import
+++ b/theme/fonts/NotoSansGeorgian_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansGeorgian_Bold.woff2-52cb92437cabb28b6
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansGeorgian_Regular.woff2.import
+++ b/theme/fonts/NotoSansGeorgian_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansGeorgian_Regular.woff2-46111eb867e12b
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansHebrew_Bold.woff2.import
+++ b/theme/fonts/NotoSansHebrew_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansHebrew_Bold.woff2-f617b2c57cf9e22ce25
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansHebrew_Regular.woff2.import
+++ b/theme/fonts/NotoSansHebrew_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansHebrew_Regular.woff2-848ab38e7684cb22
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansMalayalamUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansMalayalamUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansMalayalamUI_Bold.woff2-9d7e46bc593a52
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansMalayalamUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansMalayalamUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansMalayalamUI_Regular.woff2-e5d1120be62
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansOriyaUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansOriyaUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansOriyaUI_Bold.woff2-83f4642ca095fba343
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansOriyaUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansOriyaUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansOriyaUI_Regular.woff2-91e03b48e680f66
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansSinhalaUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansSinhalaUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansSinhalaUI_Bold.woff2-dabd79732e74b0e3
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansSinhalaUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansSinhalaUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansSinhalaUI_Regular.woff2-dee29c2d56928
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansTamilUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansTamilUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansTamilUI_Bold.woff2-4d801e2369450e24be
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansTamilUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansTamilUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansTamilUI_Regular.woff2-ba01f8e41fbaeb8
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansTeluguUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansTeluguUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansTeluguUI_Bold.woff2-d3c4287ef66852542
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansTeluguUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansTeluguUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansTeluguUI_Regular.woff2-9a88ead9abdf6e
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansThaiUI_Bold.woff2.import
+++ b/theme/fonts/NotoSansThaiUI_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansThaiUI_Bold.woff2-b690a7b4b7cb0776e50
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSansThaiUI_Regular.woff2.import
+++ b/theme/fonts/NotoSansThaiUI_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSansThaiUI_Regular.woff2-96c195d60c3cf9de
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSans_Bold.woff2.import
+++ b/theme/fonts/NotoSans_Bold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSans_Bold.woff2-a8093cd7cacca575b65175146
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/NotoSans_Regular.woff2.import
+++ b/theme/fonts/NotoSans_Regular.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/NotoSans_Regular.woff2-a8a0deb4c3becc1fa669e5
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48

--- a/theme/fonts/OpenSans_SemiBold.woff2.import
+++ b/theme/fonts/OpenSans_SemiBold.woff2.import
@@ -15,6 +15,7 @@ dest_files=["res://.godot/imported/OpenSans_SemiBold.woff2-e93c4ca78d113723f4013
 Rendering=null
 antialiasing=1
 generate_mipmaps=false
+disable_embedded_bitmaps=true
 multichannel_signed_distance_field=false
 msdf_pixel_range=8
 msdf_size=48


### PR DESCRIPTION
Closes #100 which I opened few months ago.
Today, I gave it a go and was able to add the options in the theme tab.

I added the options to set the `base _color`, `accent_color` and `contrast`.
![image](https://github.com/user-attachments/assets/c70ef167-422b-47e0-a8c6-860275632d8d)

### Problems/Stuff I couldn't figure out
- I couldn't figure out how to change the order of  **Custom Theme Guide Button** to show it at the end (without breaking anything).
![image](https://github.com/user-attachments/assets/1cca8a44-7d50-4a59-997b-18810077fd8f)
- Change `theme_preset` automatically to **Custom** if any theme property is changed (You have to manually set the `theme_preset` to **Custom** in order to get the custom theme working)
- Show the theme properties only when the `theme_preset` is set to **Custom**