### PR TITLE
Update README.md to refer to the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Fear not Linux users, unleashing the power of Godots on any distribution is just
 <a href='https://flathub.org/apps/details/io.github.MakovWait.Godots'><img width="250" alt='Download on Flathub' src='https://raw.githubusercontent.com/flxzt/rnote/main/misc/assets/flathub-badge.svg'/></a>
 </div><br>
 
+Alternatively for Arch Linux, there is the community maintained AUR Packages <a href="https://aur.archlinux.org/packages/godots-bin"> godots-bin </a> and <a href="https://aur.archlinux.org/packages/godots-git"> godot-git<a>.
+
 Don't have Flatpak? Just download the [latest release](https://github.com/MakovWait/godots/releases)!
 
 ## Features That Redefine Cool 😎


### PR DESCRIPTION
Not everyone would like to use flatpaks, and for Arch Linux, there is the lovely AUR. I am maintaining those packages there now, in a big sense of "If nobody else does it, I'll do it!".

Linking to these now in the readme, godot-bin will have the latest stable release as given from github releases, and godot-git does let the user compile the latest master branch. 