### PR TITLE
Tiny UID icon reading speed-up

### DIFF
--- a/src/services/projects.gd
+++ b/src/services/projects.gd
@@ -421,16 +421,18 @@ class ExternalProjectInfo extends RefCounted:
 		if not icon_path: return result
 		var project_path := self._project_path.get_base_dir() + "/"
 		if icon_path.begins_with("uid://"):
-			var uid_cache := FileAccess.open(project_path + ".godot/uid_cache.bin", FileAccess.READ)
-			if uid_cache.get_error() == OK:
-				var entries := uid_cache.get_32()
-				for i in entries:
-					var id := uid_cache.get_64()
-					var length := uid_cache.get_32()
-					var rl := uid_cache.get_buffer(length)
-					if ResourceUID.id_to_text(id) == icon_path:
-						icon_path = rl.get_string_from_utf8()
-						break
+			var uid := ResourceUID.text_to_id(icon_path)
+			if uid != ResourceUID.INVALID_ID:
+				var uid_cache := FileAccess.open(project_path + ".godot/uid_cache.bin", FileAccess.READ)
+				if uid_cache.get_error() == OK:
+					var entries := uid_cache.get_32()
+					for i in entries:
+						var id := uid_cache.get_64()
+						var length := uid_cache.get_32()
+						var rl := uid_cache.get_buffer(length)
+						if id == uid:
+							icon_path = rl.get_string_from_utf8()
+							break
 
 		icon_path = icon_path.replace("res://", project_path)
 		


### PR DESCRIPTION
No need for a loop of String conversions with String comparisons, which are much slower.

### Before (#135 implementation):
- Detect if icon path starts with `uid://`
- Open UID cache and get each entry
- Convert the entry's id to text (slow)
- Compare to icon path (string comparison, slow)
- Once the corresponding UID is found, give it to icon_path

### After
- Detect if icon path starts with `uid://`
- Convert the icon path UID to an integer just once
- Check if the UID is valid. If not, skip the last steps entirely.
- Open UID cache and get each entry
- Compare the entry id to the icon id (integer comparison, fast)
- Once the corresponding UID is found, give it to icon_path

Like I mentioned in #135, I did the same procedure done in Godot itself, but turns out it had this tiny overhead. I submitted this change there too.

Of course, this has been tested before submitting.

