### PR TITLE
Restore window maximized state between sessions

### DIFF
--- a/src/config.gd
+++ b/src/config.gd
@@ -162,6 +162,15 @@ var LAST_WINDOW_RECT := ConfigFileValue.new(
 	set(_v): _readonly()
 
 
+var LAST_WINDOW_MODE := ConfigFileValue.new(
+	_cfg_auto_save.as_config_like(),
+	"app",
+	"last_window_mode",
+	Window.MODE_WINDOWED
+):
+	set(_v): _readonly()
+
+
 var REMEMBER_WINDOW_SIZE := ConfigFileValue.new(
 	_cfg_auto_save.as_config_like(), 
 	"app", 

--- a/src/main/gui/gui_main.gd
+++ b/src/main/gui/gui_main.gd
@@ -177,9 +177,14 @@ func _enter_tree() -> void:
 			window.position,
 			window.min_size
 		)) as Rect2i
+		var mode: Window.Mode = Config.LAST_WINDOW_MODE.ret(Window.MODE_WINDOWED)
 		if DisplayServer.get_screen_from_rect(rect) != -1:
-			window.size = rect.size
-			window.position = rect.position
+			if mode == Window.MODE_MAXIMIZED:
+				window.mode = Window.MODE_MAXIMIZED
+			else:
+				window.mode = Window.MODE_WINDOWED
+				window.size = rect.size
+				window.position = rect.position
 	
 	_local_remote_switch_context = LocalRemoteEditorsSwitchContext.new(
 		_local_editors,
@@ -215,6 +220,7 @@ func _exit_tree() -> void:
 		callback.call()
 	var window := get_window()
 	Config.LAST_WINDOW_RECT.put(Rect2i(window.position, window.size))
+	Config.LAST_WINDOW_MODE.put(window.mode)
 
 
 # TODO type


### PR DESCRIPTION
currently, when enabling to option to restore the window size, the window if maximized will be restored as a full-screen windowed window which feels bad.
This adds a new config value, which tracks the last window mode (windowed, maximized, etc.) and restores it on startup but
1. only if the "remember window size" option is enabled
2. only for the maximized state. if minimized, the window will start up windowed