### PR TITLE
Fixing project directory creation handling & name edition when custom folder selected

### DIFF
--- a/src/components/projects/install_project_dialog/install_project_dialog.gd
+++ b/src/components/projects/install_project_dialog/install_project_dialog.gd
@@ -30,7 +30,10 @@ func _ready() -> void:
 	_create_folder_failed_dialog.add_child(_create_folder_failed_label)
 	
 	confirmed.connect(func() -> void:
-		if _create_project_dir() == OK:
+		if _create_folder_check.button_pressed:
+			if _create_project_dir() == OK:
+				_successfully_confirmed.emit()
+		else:
 			_successfully_confirmed.emit()
 	)
 	_project_name_edit.text_changed.connect(func(_arg: String) -> void:

--- a/src/components/projects/install_project_dialog/install_project_dialog.gd
+++ b/src/components/projects/install_project_dialog/install_project_dialog.gd
@@ -55,7 +55,7 @@ func _ready() -> void:
 		_file_dialog.popup_centered_ratio(0.5)
 	)
 	_file_dialog.dir_selected.connect(func(dir: String) -> void: 
-		_project_path_line_edit.text = dir
+		_project_path_line_edit.text = dir + "/"
 		_set_custom_folder = true
 		_validate()
 	)

--- a/src/components/projects/install_project_dialog/install_project_dialog.gd
+++ b/src/components/projects/install_project_dialog/install_project_dialog.gd
@@ -99,7 +99,7 @@ func _update_project_dir() -> void:
 			_project_path_line_edit.text = (Config.DEFAULT_PROJECTS_PATH.ret() as String).path_join(_format_dir_name(new_name))
 	else:
 		if _create_folder_check.button_pressed:
-			_project_path_line_edit.text = _project_path_line_edit.text.substr(0, _project_path_line_edit.text.rfind("/") + 1) + new_name
+			_project_path_line_edit.text = _project_path_line_edit.text.substr(0, _project_path_line_edit.text.rfind("/") + 1) + _format_dir_name(new_name)
 	_validate()
 
 

--- a/src/components/projects/install_project_dialog/install_project_dialog.gd
+++ b/src/components/projects/install_project_dialog/install_project_dialog.gd
@@ -56,6 +56,7 @@ func _ready() -> void:
 	)
 	_file_dialog.dir_selected.connect(func(dir: String) -> void: 
 		_project_path_line_edit.text = dir
+		_set_custom_folder = true
 		_validate()
 	)
 	
@@ -96,6 +97,9 @@ func _update_project_dir() -> void:
 			_project_path_line_edit.text = Config.DEFAULT_PROJECTS_PATH.ret() as String
 		else:
 			_project_path_line_edit.text = (Config.DEFAULT_PROJECTS_PATH.ret() as String).path_join(_format_dir_name(new_name))
+	else:
+		if _create_folder_check.button_pressed:
+			_project_path_line_edit.text = _project_path_line_edit.text.substr(0, _project_path_line_edit.text.rfind("/") + 1) + new_name
 	_validate()
 
 

--- a/src/components/projects/install_project_dialog/install_project_dialog.gd
+++ b/src/components/projects/install_project_dialog/install_project_dialog.gd
@@ -44,7 +44,8 @@ func _ready() -> void:
 		_validate()
 	)
 	_create_folder_check.toggled.connect(func(_arg: bool) -> void:
-		_update_project_dir()
+		_set_custom_folder = false
+		_toggle_auto_project_dir()
 	)
 	focus_entered.connect(func() -> void:
 		_validate()
@@ -55,9 +56,8 @@ func _ready() -> void:
 		_file_dialog.popup_centered_ratio(0.5)
 	)
 	_file_dialog.dir_selected.connect(func(dir: String) -> void: 
-		_project_path_line_edit.text = dir + "/"
-		_set_custom_folder = true
-		_validate()
+		_project_path_line_edit.text = dir
+		_update_project_dir()
 	)
 	
 	_randomize_name_button.pressed.connect(func() -> void:
@@ -72,7 +72,7 @@ func raise(project_name:="New Game Project", args: Variant = null) -> void:
 	_set_custom_folder = false
 	_project_name_edit.text = project_name
 	_project_path_line_edit.text = Config.DEFAULT_PROJECTS_PATH.ret()
-	_update_project_dir()
+	_init_project_dir()
 	popup_centered()
 	_on_raise(args)
 	_validate()
@@ -93,13 +93,28 @@ func _create_project_dir() -> Error:
 func _update_project_dir() -> void:
 	var new_name: String = _project_name_edit.text
 	if not _set_custom_folder:
+		var base_dir := _project_path_line_edit.text.get_base_dir()
 		if not _create_folder_check.button_pressed:
-			_project_path_line_edit.text = Config.DEFAULT_PROJECTS_PATH.ret() as String
+			_project_path_line_edit.text = base_dir
 		else:
-			_project_path_line_edit.text = (Config.DEFAULT_PROJECTS_PATH.ret() as String).path_join(_format_dir_name(new_name))
-	else:
+			_project_path_line_edit.text = base_dir.path_join(_format_dir_name(new_name))
+	_validate()
+
+
+func _toggle_auto_project_dir() -> void:
+	var new_name: String = _project_name_edit.text
+	if not _set_custom_folder:
 		if _create_folder_check.button_pressed:
-			_project_path_line_edit.text = _project_path_line_edit.text.substr(0, _project_path_line_edit.text.rfind("/") + 1) + _format_dir_name(new_name)
+			_project_path_line_edit.text = _project_path_line_edit.text.path_join(_format_dir_name(new_name))
+		else:
+			_project_path_line_edit.text = _project_path_line_edit.text.get_base_dir()
+	_validate()
+
+
+func _init_project_dir() -> void:
+	var new_name: String = _project_name_edit.text
+	if _create_folder_check.button_pressed:
+		_project_path_line_edit.text = _project_path_line_edit.text.path_join(_format_dir_name(new_name))
 	_validate()
 
 
@@ -127,10 +142,13 @@ func _validate() -> void:
 		return
 	
 	var dir := DirAccess.open(path)
-	
-	if not _create_folder_check.button_pressed and not dir:
-		_error(tr("The path specified doesn't exist."))
-		return
+	if not dir:
+		if _create_folder_check.button_pressed:
+			_success(tr("The project folder will be automatically created."))
+			return
+		else:
+			_error(tr("The path specified doesn't exist."))
+			return
 	
 	var parent_dir := path.get_base_dir().simplify_path()
 	if not DirAccess.dir_exists_absolute(parent_dir):
@@ -162,11 +180,8 @@ func _validate() -> void:
 	if not dir_is_empty:
 		if _handle_dir_is_not_empty(path):
 			return
-	
-	if _create_folder_check.button_pressed:
-		_success(tr("The project folder will be automatically created."))
-	else:
-		_success(tr("The project folder exists and is empty."))
+
+	_success(tr("The project folder exists and is empty."))
 
 
 func error(text: String) -> void:


### PR DESCRIPTION
Hello! First contribution here.

Commit 839b4c4 aim to fix #149 by creating folder only when `_create_folder_check` is checked on the dialog UI, else it directly emits the signal.

Commit 1fcef2c aim to fix an issue that wrongly reset the content of the `_project_path_line_edit.text` to the default config projects folder when editing the `_project_name_edit.text` .
In the commit, if `_create_folder_check` is checked, it should add a sanitized `_project_name_edit.text` to the current path after the last parent folder (fetched with the `substr()` and `rfind()` present in the commit).
If the `_create_folder_check` is not checked, we keep the implementation as it is, pulling the config default projects folder and adding the project name.

As writing this, forgot to sanitize the project name, fixing this and this should be ready to merge.