### PR TITLE
Fixing Asset Lib filter search param encoding

### DIFF
--- a/src/components/asset_lib_projects/asset_lib.gd
+++ b/src/components/asset_lib_projects/asset_lib.gd
@@ -18,9 +18,13 @@ class Params:
 				assert(el in ["official", "community", "testing"])
 			support = value
 	
-	# search text
-	var filter: String = ""
+	# raw search text
+	var filter_raw: String = ""
 	
+	# encoded search text to be used in URL 
+	var filter: String:
+		get: return filter_raw.strip_edges().uri_encode()
+
 	# submitter username
 	var user: String = ""
 	

--- a/src/components/asset_lib_projects/asset_lib_projects.gd
+++ b/src/components/asset_lib_projects/asset_lib_projects.gd
@@ -216,7 +216,7 @@ func _update_fetch_assets_status_label(items: AssetLib.Items, params: AssetLib.P
 		else:
 			_set_status(tr(
 				"No results for \"%s\" for support level(s): %s." % [
-					params.filter, _support_menu_button.get_support_string()
+					params.filter_raw, _support_menu_button.get_support_string()
 				]
 			))
 	else:

--- a/src/components/asset_lib_projects/filter_edit.gd
+++ b/src/components/asset_lib_projects/filter_edit.gd
@@ -17,7 +17,7 @@ func _init() -> void:
 
 
 func fill_params(params: AssetLib.Params) -> void:
-	params.filter = text.strip_edges()
+	params.filter = text.replace(" ", "%20").strip_edges()
 
 
 func _on_fetch_disable() -> void:

--- a/src/components/asset_lib_projects/filter_edit.gd
+++ b/src/components/asset_lib_projects/filter_edit.gd
@@ -17,7 +17,7 @@ func _init() -> void:
 
 
 func fill_params(params: AssetLib.Params) -> void:
-	params.filter = text.replace(" ", "%20").strip_edges()
+	params.filter = text.uri_encode().strip_edges()
 
 
 func _on_fetch_disable() -> void:

--- a/src/components/asset_lib_projects/filter_edit.gd
+++ b/src/components/asset_lib_projects/filter_edit.gd
@@ -17,7 +17,7 @@ func _init() -> void:
 
 
 func fill_params(params: AssetLib.Params) -> void:
-	params.filter = text.uri_encode().strip_edges()
+	params.filter_raw = text
 
 
 func _on_fetch_disable() -> void:


### PR DESCRIPTION
This commit aims to fix #155 by encoding spaces, fixing searches filter containing spaces.

Implementation is simple enough, replacing all space characters by the encoded version %20 with the built-in method, fixing the issue.