### PR TITLE
Scanning not ignoring .godot/uid_cache.bin if not existing

### DIFF
--- a/src/services/projects.gd
+++ b/src/services/projects.gd
@@ -424,15 +424,16 @@ class ExternalProjectInfo extends RefCounted:
 			var uid := ResourceUID.text_to_id(icon_path)
 			if uid != ResourceUID.INVALID_ID:
 				var uid_cache := FileAccess.open(project_path + ".godot/uid_cache.bin", FileAccess.READ)
-				if uid_cache.get_error() == OK:
-					var entries := uid_cache.get_32()
-					for i in entries:
-						var id := uid_cache.get_64()
-						var length := uid_cache.get_32()
-						var rl := uid_cache.get_buffer(length)
-						if id == uid:
-							icon_path = rl.get_string_from_utf8()
-							break
+				if uid_cache != null:
+					if uid_cache.get_error() == OK:
+						var entries := uid_cache.get_32()
+						for i in entries:
+							var id := uid_cache.get_64()
+							var length := uid_cache.get_32()
+							var rl := uid_cache.get_buffer(length)
+							if id == uid:
+								icon_path = rl.get_string_from_utf8()
+								break
 
 		icon_path = icon_path.replace("res://", project_path)
 		


### PR DESCRIPTION
This commit aims to fix #152 causing a crash after scanning projects not having a `.godot/uid_cache.bin` file. The projects.cfg was populated until the error happens, causing an irreversible situation where the app could not be launched again.

Implementation is simple, ignore the `uid_cache.bin` if not existing, the icon path will be fetched with the existing rest of the code correctly. Tested successfully with https://github.com/godotengine/godot-demo-projects as suggested in the linked issue.