### PR TITLE
Use correct `uid_cache.bin` check

### DIFF
--- a/src/services/projects.gd
+++ b/src/services/projects.gd
@@ -424,7 +424,7 @@ class ExternalProjectInfo extends RefCounted:
 			var uid := ResourceUID.text_to_id(icon_path)
 			if uid != ResourceUID.INVALID_ID:
 				var uid_cache := FileAccess.open(project_path + ".godot/uid_cache.bin", FileAccess.READ)
-				if uid_cache.get_error() == OK:
+				if uid_cache != null:
 					var entries := uid_cache.get_32()
 					for i in entries:
 						var id := uid_cache.get_64()


### PR DESCRIPTION
When writing #135 I didn't realize some differences between the engine's built-in C++ `FileAccess::open()` and GDScript's `FileAccess.open()`.

The correct way is to check if the resulting `FileAccess` isn't null, not if it has an error.

This version is even more in pair with how Godot's own project manager reads UID icons. Any possible flaws this version has may also be in Godot itself.

Fixes #152 (reproduction steps don't cause a crash anymore)
Fixes #153
Supersedes #158 (more straightforward)

I consider this urgent as the issue is a crash, so I highly recommend merging this ASAP and releasing a `1.4.1.stable`.