### PR TITLE
zip.unzip: use built-in `ZipReader` instead of `unzip` command

### DIFF
--- a/src/extensions/zip.gd
+++ b/src/extensions/zip.gd
@@ -2,45 +2,25 @@ class_name zip
 
 static func unzip(zip_path: String, target_dir: String) -> void:
 	DirAccess.make_dir_absolute(target_dir)
+	var reader := ZIPReader.new()
+	if reader.open(zip_path) == OK:
+		var destination := DirAccess.open(target_dir)
+		for zip_file_name in reader.get_files():
+			if zip_file_name.ends_with("/"):
+				destination.make_dir_recursive(zip_file_name)
+				continue
 
-	var output := []
-	var exit_code: int
-	if OS.has_feature("windows"):
-		exit_code = OS.execute(
-			"powershell.exe", 
-			[
-				"-command",
-				"\"Expand-Archive '%s' '%s'\" -Force" % [ 
-					ProjectSettings.globalize_path(zip_path), 
-					ProjectSettings.globalize_path(target_dir)
-				]
-			], output, true
-		)
-		Output.push(output.pop_front())
-		Output.push("unzip executed with exit code: %s" % exit_code)
-	elif OS.has_feature("macos"):
-		exit_code = OS.execute(
-			"unzip", 
-			[
-				"%s" % ProjectSettings.globalize_path(zip_path), 
-				"-d", 
-				"%s" % ProjectSettings.globalize_path(target_dir)
-			], output, true
-		)
-		Output.push(output.pop_front())
-		Output.push("unzip executed with exit code: %s" % exit_code)
-	elif OS.has_feature("linux"):
-		exit_code = OS.execute(
-			"unzip",
-			[
-				"-o",
-				"%s" % ProjectSettings.globalize_path(zip_path), 
-				"-d",
-				"%s" % ProjectSettings.globalize_path(target_dir)
-			], output, true
-		)
-		Output.push(output.pop_front())
-		Output.push("unzip executed with exit code: %s" % exit_code)
+			var file_contents := reader.read_file(zip_file_name)
+			var file_path := destination.get_current_dir().path_join(zip_file_name)
+			destination.make_dir_recursive(file_path.get_base_dir())
+			var file := FileAccess.open(file_path, FileAccess.WRITE)
+			if not file:
+				reader.close()
+				return
+			file.store_buffer(file_contents)
+			file.close()
+
+	reader.close()
 
 
 ## A procedure that unzips a zip file to a target directory, keeping the


### PR DESCRIPTION
Another approach like #131. Closes #130.

Code is mostly taken from Godot's own documentation tutorial for unzipping files. 

Installing an editor this way works just fine, but likely needs to be tested in other platforms (tested on Linux).

Despite looking like a lazy copy of `unzip_to_path()`, I think it's important to get rid of the `unzip` command's need.