### PR TITLE
Optimize UID icon reading even further

### DIFF
--- a/src/services/projects.gd
+++ b/src/services/projects.gd
@@ -429,10 +429,11 @@ class ExternalProjectInfo extends RefCounted:
 					for i in entries:
 						var id := uid_cache.get_64()
 						var length := uid_cache.get_32()
-						var rl := uid_cache.get_buffer(length)
 						if id == uid:
-							icon_path = rl.get_string_from_utf8()
+							icon_path = uid_cache.get_buffer(length).get_string_from_utf8()
 							break
+						else:
+							uid_cache.seek(uid_cache.get_position() + length)
 
 		icon_path = icon_path.replace("res://", project_path)
 		


### PR DESCRIPTION
Prevents the system from allocating memory for every UID in the file before the target. Instead, allocate just for the target.

Although I don't think the improvement will be that significant since this is GDScript.