### PR TITLE
Fix truncated Directory when selecting 

### DIFF
--- a/src/components/projects/install_project_dialog/install_project_dialog.gd
+++ b/src/components/projects/install_project_dialog/install_project_dialog.gd
@@ -93,7 +93,7 @@ func _create_project_dir() -> Error:
 func _update_project_dir() -> void:
 	var new_name: String = _project_name_edit.text
 	if not _set_custom_folder:
-		var base_dir := _project_path_line_edit.text.get_base_dir()
+		var base_dir := _project_path_line_edit.text
 		if not _create_folder_check.button_pressed:
 			_project_path_line_edit.text = base_dir
 		else:


### PR DESCRIPTION
Resolves #175 

Removed get_base_dir() call to prevent the current selected directory from being truncated from the path for the project.

### Explanation
(taken from https://github.com/MakovWait/godots/issues/175#issuecomment-4534996324)
> Looking into it, this bit of code seems to be causing the issue:
>
``` gdscript 
func _update_project_dir() -> void:
	var new_name: String = _project_name_edit.text
	if not _set_custom_folder:
		var base_dir := _project_path_line_edit.text.get_base_dir()  <- this line
		if not _create_folder_check.button_pressed:
			_project_path_line_edit.text = base_dir
		else:
			_project_path_line_edit.text = base_dir.path_join(_format_dir_name(new_name))
	_validate()
```
> 
> what happens is that earlier `_project_path_line_edit.text` gets set to `base/current`. for example `User/Documents/Godot Projects`. when `var base_dir := _project_path_line_edit.text.get_base_dir()` happens, it strips the end of the path to no longer point to the current selected directory, but instead the one above. so with the previous example, it would turn into `User/Documents`.